### PR TITLE
Python 2 compatability

### DIFF
--- a/mkyxdata.sh
+++ b/mkyxdata.sh
@@ -3,6 +3,6 @@ advertisers="all 1458 2261 2997 3386 3476 2259 2821 3358 3427"
 
 for advertiser in $advertisers; do
     echo $advertiser
-    python python/mkyx.py $advertiser/train.log.txt $advertiser/test.log.txt $advertiser/train.txt $advertiser/test.txt $advertiser/featindex.txt
+    python2 python/mkyx.py $advertiser/train.log.txt $advertiser/test.log.txt $advertiser/train.txt $advertiser/test.txt $advertiser/featindex.txt
 done
 


### PR DESCRIPTION
Ensure that script runs python 2.x, otherwise the `print` command raises exceptions.